### PR TITLE
Update names to match buildpack

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "PgBouncer exporter"
+echo "pgbouncer_exporter"
 exit 0

--- a/bin/start-pgbouncer-exporter
+++ b/bin/start-pgbouncer-exporter
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# start-alloy --config=<config> <command>
+# start-pgbouncer-exporter <command>
 #
 # This script acts as a process manager, of two children, waiting for either
-# alloy or the chained command to return before exiting.
+# pgbouncer-exporter or the chained command to return before exiting.
 #
 #
 # Delegates SIGTERM to the children on signal or child exit


### PR DESCRIPTION
- Updates the reference to "alloy" buildpack.
- Aligns the log line to match buildpack=$(bin/detect)
